### PR TITLE
Schema modifications to work with validators

### DIFF
--- a/isebel2.xsd
+++ b/isebel2.xsd
@@ -212,7 +212,7 @@
 	<xs:complexType name="typePerson">
 		<xs:sequence>
 			<xs:element name="name" type="xs:string" />
-			<xs:element name="gender" type="xs:string" />
+			<xs:element name="gender" minOccurs="0" type="xs:string" />
 			<xs:element name="role" type="typePersonRole" maxOccurs="unbounded" />
 			<xs:element name="profession" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
 			<xs:element name="birthDate" type="xs:date" minOccurs="0" />

--- a/isebel2.xsd
+++ b/isebel2.xsd
@@ -16,11 +16,9 @@
 	<xs:import namespace="http://www.w3.org/XML/1998/namespace"
 		schemaLocation="http://www.w3.org/2001/xml.xsd" />
 	<xs:import namespace="http://purl.org/dc/elements/1.1/"
-		schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd" />
-	<xs:import namespace="http://purl.org/dc/terms/"
-		schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd" />
+		schemaLocation="http://dublincore.org/schemas/xmls/qdc/2003/04/02/dc.xsd" />
 	<xs:import namespace="http://datacite.org/schema/kernel-4"
-		schemaLocation="https://schema.datacite.org/meta/kernel-4.2/metadata.xsd" />
+		schemaLocation="http://schema.datacite.org/meta/kernel-4.2/metadata.xsd" />
 
 
 	<!-- The story as the only valid XML root element. -->
@@ -239,7 +237,6 @@
 		</xs:sequence>
 		<xs:attribute ref="xml:lang" />
 		<xs:attribute name="id" type="xs:string" />
-		<xs:assert test="exists(dc:title) or exists(date)" />
 	</xs:complexType>
 
 

--- a/isebel2.xsd
+++ b/isebel2.xsd
@@ -16,9 +16,9 @@
 	<xs:import namespace="http://www.w3.org/XML/1998/namespace"
 		schemaLocation="http://www.w3.org/2001/xml.xsd" />
 	<xs:import namespace="http://purl.org/dc/elements/1.1/"
-		schemaLocation="http://dublincore.org/schemas/xmls/qdc/2003/04/02/dc.xsd" />
+		schemaLocation="https://www.dublincore.org/schemas/xmls/qdc/dc.xsd" />
 	<xs:import namespace="http://datacite.org/schema/kernel-4"
-		schemaLocation="http://schema.datacite.org/meta/kernel-4.2/metadata.xsd" />
+		schemaLocation="https://schema.datacite.org/meta/kernel-4/metadata.xsd" />
 
 
 	<!-- The story as the only valid XML root element. -->

--- a/isebel2.xsd
+++ b/isebel2.xsd
@@ -30,7 +30,7 @@
 				<xs:element ref="dc:identifier" />
 
 				<!-- Story title (multiple titles for different languages). -->
-				<xs:element ref="dc:title" maxOccurs="unbounded" />
+				<xs:element ref="dc:title" minOccurs="0" maxOccurs="unbounded" />
 
 				<!-- Content genre information (not media type). -->
 				<xs:element ref="dc:type" minOccurs="0" maxOccurs="unbounded" />


### PR DESCRIPTION
These modifications don't add or remove any elements from the schema; rather they remove extraneous external schema requirements and make it OK for a story not to have a title (which is the case for a lot of folklore) and for the gender of an informant to be unknown.

All of these changes were necessary to enable the Danish stories to validate against the `isebel2` schema using a tool like `xmllint`. Other corpus contributors in the future likely will wish to check that their OAI-PMH story feeds also validate, so these updates likely will help them as well.