### PR TITLE
Update isebel2.xsd

### DIFF
--- a/xsd_test/isebel2.xsd
+++ b/xsd_test/isebel2.xsd
@@ -48,6 +48,20 @@
         <xs:attribute name="title" type="xs:string"/>
     </xs:complexType>
 
+
+    <!-- Container type for all motifs. -->
+    <xs:complexType name="typeMotifs">
+        <xs:sequence>
+            <xs:element name="motif" type="typeMotif" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Motif type. -->
+    <xs:complexType name="typeMotif">
+        <xs:attribute name="number" type="xs:string" use="required"/>
+        <xs:attribute name="title" type="xs:string"/>
+    </xs:complexType>
+
     <!-- Container type for all story texts. -->
     <xs:complexType name="typeContents">
         <xs:sequence>
@@ -255,6 +269,9 @@
 
                 <!-- Tale type information. -->
                 <xs:element name="taleTypes" type="typeTaleTypes" minOccurs="0"/>
+
+                <!-- Motif information. -->
+                <xs:element name="motifs" type="typeMotifs" minOccurs="0"/>
 
                 <!-- Story text (multiple texts for different languages)? -->
                 <xs:element name="contents" type="typeContents"/>


### PR DESCRIPTION
I've added the motif elements, we talked about a few weeks ago. Since they are optional, existing providers won't break the schema. It's pretty much the same as tale types, so it's going to be mainly copy and paste, when it comes to the implementation of the schema change.